### PR TITLE
chore: update near-sdk-js version

### DIFF
--- a/contract-ts/package.json
+++ b/contract-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coin_flip",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "(MIT AND Apache-2.0)",
   "type": "module",
   "scripts": {
@@ -8,7 +8,7 @@
     "test": "$npm_execpath run build && ava -- ./build/coin_flip.wasm"
   },
   "dependencies": {
-    "near-sdk-js": "1.0.0"
+    "near-sdk-js": "2.0.0"
   },
   "devDependencies": {
     "ava": "^6.1.3",


### PR DESCRIPTION
update near-sdk-js version to 2.0.0: https://github.com/near/near-sdk-js/issues/389